### PR TITLE
dev(client): add file watcher script

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
         "src/pages/index.html"
     ],
     "scripts": {
-        "build": "parcel build"
+        "build": "parcel build",
+        "watch": "parcel watch"
     },
     "devDependencies": {
         "@parcel/config-default": "^2.8.3",


### PR DESCRIPTION
Last Wednesday, I noticed how much a hassle it was for everyone to keep running `pnpm build` before changes register in the front end. This PR alleviates that workflow by introducing `pnpm watch`, which watches over the dependency graph of Parcel and recompiles files _as needed_. This should significantly improve the feedback loop because `pnpm build` builds from scratch whereas `pnpm watch` only recompiles assets that have changed. We still have to force-reload the browser window, though.