### PR TITLE
feat(server): enforce permissions for all endpoints

### DIFF
--- a/client/src/api/batch.ts
+++ b/client/src/api/batch.ts
@@ -35,6 +35,7 @@ export namespace Batch {
             case NOT_FOUND: return null;
             case BAD_REQUEST: throw new InvalidInput;
             case UNAUTHORIZED: throw new InvalidSession;
+            case FORBIDDEN: throw new InsufficientPermissions;
             case NOT_ACCEPTABLE: throw new BadContentNegotiation;
             default: throw new UnexpectedStatusCode;
         }

--- a/model/src/permission.ts
+++ b/model/src/permission.ts
@@ -22,6 +22,6 @@ export enum Global {
     CreateCategory = 8,
     UpdateCategory = 16,
     DeleteCategory = 32,
-    ReactivateCategory = 64,
+    ActivateCategory = 64,
     ViewMetrics = 128,
 }

--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -11,7 +11,8 @@ CREATE DOMAIN AuthorizationCode AS VARCHAR(256) NOT NULL;
 CREATE DOMAIN Expiration AS TIMESTAMPTZ NOT NULL CHECK(VALUE > NOW());
 
 -- Permission Bits
-CREATE DOMAIN Permission AS BIT VARYING(3) NOT NULL;
+CREATE DOMAIN LocalPermission AS BIT VARYING(12) NOT NULL;
+CREATE DOMAIN GlobalPermission AS BIT VARYING(8) NOT NULL;
 
 -- Push Subscription Endpoint
 CREATE DOMAIN Endpoint AS VARCHAR(50) NOT NULL;
@@ -25,7 +26,7 @@ CREATE TABLE users(
     name VARCHAR(40) NOT NULL,
     email VARCHAR(32) UNIQUE NOT NULL,
     picture VARCHAR(256) NOT NULL,
-    permission Permission,
+    permission GlobalPermission,
     PRIMARY KEY (id)
 );
 
@@ -55,7 +56,7 @@ CREATE TABLE office(
 CREATE TABLE staff(
     user_id GoogleUserId REFERENCES users (id),
     office SMALLINT NOT NULL REFERENCES office (id),
-    permission Permission,
+    permission LocalPermission,
     PRIMARY KEY (user_id, office)
 );
 
@@ -115,7 +116,7 @@ CREATE TABLE notification(
 CREATE TABLE invitation(
     office SMALLSERIAL NOT NULL REFERENCES office (id),
     email VARCHAR(20) NOT NULL,
-    permission Permission NOT NULL,
+    permission LocalPermission NOT NULL,
     creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (office, email)
 );

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -122,7 +122,7 @@ export class Database {
     async upsertInvitation({ office, email, permission }: Omit<Invitation, 'creation'>): Promise<Invitation['creation'] | null> {
         const { rows: [ first, ...rest ] } = await this.#client
             .queryObject`INSERT INTO invitation (office,email,permission)
-                SELECT * FROM (SELECT ${office}::SMALLINT,${email},${permission}::Permission) AS data
+                SELECT * FROM (SELECT ${office}::SMALLINT,${email},${permission}::LocalPermission) AS data
                     WHERE NOT EXISTS (SELECT 1 FROM users AS u WHERE u.email = ${email}) LIMIT 1
                 ON CONFLICT (office,email) DO UPDATE SET permission = ${permission}, creation = DEFAULT
                 RETURNING creation`;

--- a/server/src/routes/api/batch.ts
+++ b/server/src/routes/api/batch.ts
@@ -5,6 +5,7 @@ import { accepts } from 'negotiation';
 import { Pool } from 'postgres';
 
 import type { GeneratedBatch, MinBatch } from '~model/api.ts';
+import { Local } from '~model/permission.ts';
 
 import { Database } from '../../database.ts';
 
@@ -19,6 +20,7 @@ import { Database } from '../../database.ts';
  * - `200` => returns a {@linkcode MinBatch} as JSON in the {@linkcode Response} body
  * - `400` => office ID is unacceptable
  * - `401` => session ID is absent, expired, or otherwise malformed
+ * - `403` => insufficient permissions
  * - `404` => no batches have been generated yet
  * - `406` => content negotiation failed
  */
@@ -43,10 +45,15 @@ export async function handleGetEarliestAvailableBatch(pool: Pool, req: Request, 
 
     const db = await Database.fromPool(pool);
     try {
-        const valid = await db.checkValidSession(sid);
-        if (!valid) {
+        const staff = await db.getStaffFromSession(sid, oid);
+        if (staff === null) {
             error(`[Batch] Invalid session ${sid}`);
             return new Response(null, { status: Status.Unauthorized });
+        }
+
+        if ((staff.permission & Local.ViewBatch) === 0) {
+            error(`[Batch] Session ${sid} cannot view earliest batch`);
+            return new Response(null, { status: Status.Forbidden });
         }
 
         const result: MinBatch | null = await db.getEarliestAvailableBatch(oid);
@@ -55,7 +62,7 @@ export async function handleGetEarliestAvailableBatch(pool: Pool, req: Request, 
             return new Response(null, { status: Status.NotFound });
         }
 
-        info(`[Batch] Session ${sid} requested a list of ${result.codes.length} barcodes from batch ${result.batch}`);
+        info(`[Batch] User ${staff.user_id} requested a list of ${result.codes.length} barcodes from batch ${result.batch}`);
         return new Response(JSON.stringify(result), {
             headers: { 'Content-Type': 'application/json' },
         });

--- a/server/src/routes/api/category.ts
+++ b/server/src/routes/api/category.ts
@@ -6,6 +6,7 @@ import { accepts } from 'negotiation';
 import { Pool } from 'postgres';
 
 import type { Category } from '~model/category.ts';
+import { Global } from '~model/permission.ts';
 
 import { Database } from '../../database.ts';
 
@@ -103,7 +104,11 @@ export async function handleCreateCategory(pool: Pool, req: Request) {
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        // TODO: check global permissions
+        if ((user.permission & Global.CreateCategory) === 0) {
+            error(`[Category] User ${user.id} ${user.name} <${user.email}> cannot create new category "${category}"`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
         const id = await db.createCategory(category);
         if (id === null) {
             error(`[Category] User ${user.id} ${user.name} <${user.email}> attempted to create duplicate category "${category}"`);

--- a/server/src/routes/api/document.ts
+++ b/server/src/routes/api/document.ts
@@ -144,9 +144,13 @@ export async function handleGetInbox(pool: Pool, req: Request, params: URLSearch
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        // TODO: check local permissions
+        if ((staff.permission & Local.ViewInbox) === 0) {
+            error(`[Document] User ${staff.user_id} cannot retrieve the inbox for office ${oid}`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
         const inbox: InboxEntry[] = await db.getInbox(oid);
-        info(`[Document] Session ${sid} retrieved the inbox for office ${oid}`);
+        info(`[Document] User ${staff.user_id} retrieved the inbox for office ${oid}`);
         return new Response(JSON.stringify(inbox), {
             headers: { 'Content-Type': 'application/json' },
         });

--- a/server/src/routes/api/invite.ts
+++ b/server/src/routes/api/invite.ts
@@ -154,14 +154,18 @@ export async function handleRevokeInvitation(pool: Pool, req: Request, params: U
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        // TODO: check local permissions
+        if ((staff.permission & Local.RevokeInvite) === 0) {
+            error(`[Invite] User ${staff.user_id} cannot revoke existing email <${email}> to office ${oid}`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
         const revokeResult = await db.revokeInvitation(oid, email);
         if (revokeResult === null) {
-            error(`[Invite] Session ${sid} attempted to revoke non-existent invitation <${email}> from office ${oid}`);
+            error(`[Invite] User ${staff.user_id} attempted to revoke non-existent invitation <${email}> from office ${oid}`);
             return new Response(null, { status: Status.NotFound });
         }
 
-        info(`[Invite] Session ${sid} revoked invitation <${email}> from office ${oid}`);
+        info(`[Invite] User ${staff.user_id} revoked invitation <${email}> from office ${oid}`);
         return new Response(JSON.stringify(revokeResult), {
             headers: { 'Content-Type': 'application/json' },
             status: Status.OK,

--- a/server/src/routes/api/office.ts
+++ b/server/src/routes/api/office.ts
@@ -5,6 +5,8 @@ import { accepts } from 'negotiation';
 import { parseMediaType } from 'parse-media-type';
 import { Pool } from 'postgres';
 
+import { Global } from '~model/permission.ts';
+
 import { Database } from '../../database.ts';
 
 /**
@@ -59,7 +61,11 @@ export async function handleCreateOffice(pool: Pool, req: Request) {
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        // TODO: check global permissions
+        if ((operator.permission & Global.CreateOffice) === 0) {
+            error(`[Office] User ${operator.id} ${operator.name} <${operator.email}> cannot create new office "${name}"`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
         const office = await db.createOffice(name);
         info(`[Office] User ${operator.id} ${operator.name} <${operator.email}> created new office ${office} "${name}"`);
         return new Response(office.toString(), {

--- a/server/src/routes/api/staff.ts
+++ b/server/src/routes/api/staff.ts
@@ -147,14 +147,18 @@ export async function handleRemoveStaff(pool: Pool, req: Request, params: URLSea
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        // TODO: Check permissions
+        if ((staff.permission & Local.RemoveStaff) === 0) {
+            error(`[Category] User ${staff.user_id} cannot retire staff member with user ID ${user} in office ${oid}`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
         const result = await db.removeStaff(user, oid);
         if (result === null) {
-            error(`[Staff] Session ${sid} attempted to retire staff member with non-existent user ${user} or office ${oid}`);
+            error(`[Staff] User ${staff.user_id} attempted to retire staff member with non-existent user ${user} or office ${oid}`);
             return new Response(null, { status: Status.NotFound });
         }
 
-        info(`[Category] Session ${sid} retired staff member with user ${user} and office ${oid}`);
+        info(`[Category] User ${staff.user_id} retired staff member with user ${user} and office ${oid}`);
         return new Response(null, { status: result ? Status.NoContent : Status.Accepted });
     } finally {
         db.release();

--- a/server/src/routes/api/user.ts
+++ b/server/src/routes/api/user.ts
@@ -4,6 +4,8 @@ import { error, info } from 'log';
 import { parseMediaType } from 'parse-media-type';
 import { Pool } from 'postgres';
 
+import { Global } from '~model/permission.ts';
+
 import { Database } from '../../database.ts';
 
 /**
@@ -62,7 +64,12 @@ export async function handleSetUserPermissions(pool: Pool, req: Request, params:
             return new Response(null, { status: Status.Unauthorized });
         }
 
-        // TODO: Check permissions and escalation prevention
+        if ((admin.permission & Global.UpdateUser) === 0) {
+            error(`[User] User ${admin.id} ${admin.name} <${admin.email}> cannot set the staff permissions of user ${user} as ${setPerms}`);
+            return new Response(null, { status: Status.Forbidden });
+        }
+
+        // FIXME: Prevent escalation prevention
         if (await db.setUserPermissions(user, setPerms)) {
             info(`[User] User ${admin.id} ${admin.name} <${admin.email}> set the staff permissions of user ${user} as ${setPerms}`);
             return new Response(null, { status: Status.NoContent });


### PR DESCRIPTION
PR #7 finalizes the format for the permission bit string. This PR implements the specification across all API endpoints implemented thus far. When the permission bit mask is incompatible, the endpoints simply return a null response with status code `403 Forbidden`.