### PR TITLE
refactor(client): change IconSize attribute to CSS class

### DIFF
--- a/client/src/components/Icons/Add.svelte
+++ b/client/src/components/Icons/Add.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/add.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Barcode.svelte
+++ b/client/src/components/Icons/Barcode.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/barcode.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/BareMetalServer.svelte
+++ b/client/src/components/Icons/BareMetalServer.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/bare-metal-server.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Camera.svelte
+++ b/client/src/components/Icons/Camera.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/camera.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/ChartClusterBar.svelte
+++ b/client/src/components/Icons/ChartClusterBar.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/chart-cluster-bar.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/CheckboxIndeterminateFilled.svelte
+++ b/client/src/components/Icons/CheckboxIndeterminateFilled.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/checkbox-indeterminate-filled.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Checkmark.svelte
+++ b/client/src/components/Icons/Checkmark.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/checkmark.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/ChevronLeft.svelte
+++ b/client/src/components/Icons/ChevronLeft.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/chevron-left.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Close.svelte
+++ b/client/src/components/Icons/Close.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/close.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/CloudLogging.svelte
+++ b/client/src/components/Icons/CloudLogging.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/cloud-logging.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/DocumentAdd.svelte
+++ b/client/src/components/Icons/DocumentAdd.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/document-add.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/DocumentBlank.svelte
+++ b/client/src/components/Icons/DocumentBlank.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/document-blank.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/DocumentDownload.svelte
+++ b/client/src/components/Icons/DocumentDownload.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/document-download.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/DocumentExport.svelte
+++ b/client/src/components/Icons/DocumentExport.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/document-export.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/DocumentImport.svelte
+++ b/client/src/components/Icons/DocumentImport.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/document-import.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Download.svelte
+++ b/client/src/components/Icons/Download.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/download.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Edit.svelte
+++ b/client/src/components/Icons/Edit.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/edit.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Events.svelte
+++ b/client/src/components/Icons/Events.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/events.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Eye.svelte
+++ b/client/src/components/Icons/Eye.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/eye.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/EyeSlash.svelte
+++ b/client/src/components/Icons/EyeSlash.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/eye-slash.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Google.svelte
+++ b/client/src/components/Icons/Google.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/google.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Icons-Template.svelte
+++ b/client/src/components/Icons/Icons-Template.svelte
@@ -3,13 +3,12 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
     const iconUrl = new URL('../../assets/document-blank.svg', import.meta.url);
 
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/LockFill.svelte
+++ b/client/src/components/Icons/LockFill.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/lock-fill.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Logout.svelte
+++ b/client/src/components/Icons/Logout.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/logout.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Notification.svelte
+++ b/client/src/components/Icons/Notification.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/notification.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/NotificationOff.svelte
+++ b/client/src/components/Icons/NotificationOff.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/notification-off.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/OverflowMenuHorizontal.svelte
+++ b/client/src/components/Icons/OverflowMenuHorizontal.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/overflow-menu-horizontal.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/OverflowMenuVertical.svelte
+++ b/client/src/components/Icons/OverflowMenuVertical.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/overflow-menu-vertical.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Person.svelte
+++ b/client/src/components/Icons/Person.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/PersonAdd.svelte
+++ b/client/src/components/Icons/PersonAdd.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person-add.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/PersonDelete.svelte
+++ b/client/src/components/Icons/PersonDelete.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person-delete.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/PersonInfo.svelte
+++ b/client/src/components/Icons/PersonInfo.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person-info.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/PersonMail.svelte
+++ b/client/src/components/Icons/PersonMail.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person-mail.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/PersonPending.svelte
+++ b/client/src/components/Icons/PersonPending.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person-pending.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/PersonSettings.svelte
+++ b/client/src/components/Icons/PersonSettings.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/person-settings.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Search.svelte
+++ b/client/src/components/Icons/Search.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/search.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/SendAlt.svelte
+++ b/client/src/components/Icons/SendAlt.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/send-alt.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/Settings.svelte
+++ b/client/src/components/Icons/Settings.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/settings.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/StopOutlineFilled.svelte
+++ b/client/src/components/Icons/StopOutlineFilled.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/stop-outline-filled.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/UnlockFill.svelte
+++ b/client/src/components/Icons/UnlockFill.svelte
@@ -3,12 +3,11 @@
     import { IconColor, IconSize } from '../types.ts';
     
     export let color = IconColor.Default;
-    export let width = IconSize.Normal;
+    export let size = IconSize.Normal;
     export let alt = '';
-    export let height = IconSize.Normal;
 
     // Replace the next lines to generate an icon.
 	const iconUrl = new URL('../../assets/unlock-fill.svg', import.meta.url);
 </script>
 
-<img class="{color}" {width} {height} {alt} src="{iconUrl.pathname}" on:click on:keydown />
+<img class="{color} {size}" {alt} src="{iconUrl.pathname}" on:click on:keydown />

--- a/client/src/components/Icons/icon-styles.css
+++ b/client/src/components/Icons/icon-styles.css
@@ -3,6 +3,7 @@
     --medium: 1.25rem;
     --large: 1.5rem;
 }
+
 .faded {
     filter: invert(73%) sepia(4%) saturate(555%) hue-rotate(171deg) brightness(95%) contrast(94%);
 }

--- a/client/src/components/Icons/icon-styles.css
+++ b/client/src/components/Icons/icon-styles.css
@@ -1,3 +1,8 @@
+:root {
+    --normal: 1rem;
+    --medium: 1.25rem;
+    --large: 1.5rem;
+}
 .faded {
     filter: invert(73%) sepia(4%) saturate(555%) hue-rotate(171deg) brightness(95%) contrast(94%);
 }
@@ -8,4 +13,19 @@
 
 .default {
     filter: none;
+}
+
+.normal {
+    width: var(--normal);
+    height: var(--normal);
+}
+
+.medium {
+    width: var(--medium);
+    height: var(--medium);
+}
+
+.large {
+    width: var(--large);
+    height: var(--large);
 }


### PR DESCRIPTION
This PR aims to replace the IconSize attribute to refer to a CSS class instead of an inline style.