### PR TITLE
refactor(server/cache): extract caching logic to own file

### DIFF
--- a/server/src/cache.ts
+++ b/server/src/cache.ts
@@ -1,0 +1,66 @@
+import { assert } from 'asserts';
+import { debug, info, warning } from 'log';
+import { z } from 'zod';
+
+import { KeySchema } from './model/jwk/key.ts';
+
+async function loadCachedResource<T>(name: string, url: string, schema: z.ZodType<T>): Promise<T> {
+    const cache = await caches.open(name);
+    const maybeResponse = await cache.match(url);
+
+    // Check cached value first
+    if (maybeResponse !== undefined) {
+        info(`[Cache] Cache "${name}" hit ${url}`);
+        const expires = maybeResponse.headers.get('Expires');
+        assert(expires);
+
+        const expiration = new Date(expires);
+        info(`[Cache] Cached response for "${name}" expires at ${expiration.toLocaleString()}`)
+
+        if (new Date < expiration) {
+            debug(`[Cache ${name}] Using ${url}`);
+            const json = await maybeResponse.json();
+            return schema.parse(json);
+        }
+
+        assert(await cache.delete(url));
+        warning(`[Cache] Cache "${name}" busted ${url}`);
+    }
+
+    // Otherwise fetch a new copy
+    info(`[Cache] Fetching ${url}`);
+    const response = await fetch(url);
+    assert(response.ok);
+    const clone = response.clone();
+    const json = schema.parse(await response.json());
+    await cache.put(url, clone);
+    return json;
+}
+
+const DISCOVERY_URL = 'https://accounts.google.com/.well-known/openid-configuration';
+const DiscoveryDocumentSchema = z.object({
+    issuer: z.string().url(),
+    authorization_endpoint: z.string().url(),
+    token_endpoint: z.string().url(),
+    userinfo_endpoint: z.string().url(),
+    revocation_endpoint: z.string().url(),
+    jwks_uri: z.string().url(),
+});
+export function getDiscoveryDocument() {
+    return loadCachedResource('discovery', DISCOVERY_URL, DiscoveryDocumentSchema);
+}
+
+const CertsResponse = z.object({ keys: KeySchema.passthrough().array() });
+export async function getCerts() {
+    const { jwks_uri } = await getDiscoveryDocument();
+    const { keys } = await loadCachedResource('certs', jwks_uri, CertsResponse);
+    const map = new Map<string, CryptoKey>();
+    for (const jwk of keys) {
+        const options = jwk.alg === 'RS256'
+            ? { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }
+            : { name: 'ECDSA', namedCurve: 'P-256' };
+        const key = await crypto.subtle.importKey('jwk', jwk, options, false, [ 'verify' ]);
+        map.set(jwk.kid, key);
+    }
+    return map;
+}

--- a/server/src/model/oauth/openid.ts
+++ b/server/src/model/oauth/openid.ts
@@ -1,75 +1,13 @@
-import { assert } from 'asserts';
-import { debug, info, warning } from 'log';
 import { z } from 'zod';
 
 import { env } from '../../env.ts';
-import { KeySchema } from '../jwk/key.ts';
-
-const DiscoveryDocumentSchema = z.object({
-    issuer: z.string().url(),
-    authorization_endpoint: z.string().url(),
-    token_endpoint: z.string().url(),
-    userinfo_endpoint: z.string().url(),
-    revocation_endpoint: z.string().url(),
-    jwks_uri: z.string().url(),
-});
-
-const DISCOVERY_URL = 'https://accounts.google.com/.well-known/openid-configuration';
-
-async function loadCachedResource<T>(name: string, url: string, schema: z.ZodType<T>): Promise<T> {
-    const cache = await caches.open(name);
-    const maybeResponse = await cache.match(url);
-
-    // Check cached value first
-    if (maybeResponse !== undefined) {
-        info(`[Cache ${name}] Hit ${url}`);
-        const expires = maybeResponse.headers.get('Expires');
-        assert(expires);
-
-        const expiration = new Date(expires);
-        info(`[Cache ${name}] Cached response expires at ${expiration.toLocaleString()}`)
-
-        if (new Date < expiration) {
-            debug(`[Cache ${name}] Using ${url}`);
-            const json = await maybeResponse.json();
-            return schema.parse(json);
-        }
-
-        assert(await cache.delete(url));
-        warning(`[Cache ${name}] Busting ${url}`);
-    }
-
-    // Otherwise fetch a new copy
-    info(`[Cache] Fetching ${url}`);
-    const response = await fetch(url);
-    assert(response.ok);
-    const clone = response.clone();
-    const json = schema.parse(await response.json());
-    await cache.put(url, clone);
-    return json;
-}
-
-export const DISCOVERY = await loadCachedResource('discovery', DISCOVERY_URL, DiscoveryDocumentSchema);
-info('[Discovery] Initialized');
-
-const { keys } = await loadCachedResource('certs', DISCOVERY.jwks_uri, z.object({ keys: KeySchema.passthrough().array() }));
-info('[Certs] Initialized');
-
-const map = new Map<string, CryptoKey>();
-for (const jwk of keys) {
-    const options = jwk.alg === 'RS256'
-        ? { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }
-        : { name: 'ECDSA', namedCurve: 'P-256' };
-    const key = await crypto.subtle.importKey('jwk', jwk, options, false, [ 'verify' ]);
-    map.set(jwk.kid, key);
-}
-
-export const KEYS = map;
+import { getDiscoveryDocument } from '../../cache.ts';
 
 const UNIX_TIME_SECS = z.number().int().transform(secs => new Date(secs * 1000));
 
 export const GoogleUserId = z.string().min(1).max(255);
 
+const { issuer } = await getDiscoveryDocument();
 export const IdTokenSchema = z.object({
     // OpenID audience.
     aud: z.literal(env.GOOGLE_ID),
@@ -80,7 +18,7 @@ export const IdTokenSchema = z.object({
     // Expiration time (in seconds) on or after which the token is invalid.
     exp: UNIX_TIME_SECS,
     // OpenID issuer.
-    iss: z.literal(DISCOVERY.issuer),
+    iss: z.literal(issuer),
     // OpenID authorized presenter.
     azp: z.string().min(1),
     // Access token hash.

--- a/server/src/routes/auth/callback.ts
+++ b/server/src/routes/auth/callback.ts
@@ -6,10 +6,10 @@ import { Status } from 'http';
 import { Pool } from 'postgres';
 
 import { hashUuid, parseJwt } from './util.ts';
+import { getDiscoveryDocument } from '../../cache.ts';
 import { Database } from '../../database.ts';
 import { env } from '../../env.ts';
 import { AuthorizationCode, TokenResponseSchema } from '../../model/oauth/google.ts';
-import { DISCOVERY } from '../../model/oauth/openid.ts';
 
 export async function handleCallback(pool: Pool, req: Request, params: URLSearchParams) {
     // Redirect to start of log-in flow if no session ID
@@ -49,7 +49,9 @@ export async function handleCallback(pool: Pool, req: Request, params: URLSearch
             redirect_uri: env.OAUTH_REDIRECT,
             grant_type: 'authorization_code',
         });
-        const response = await fetch(DISCOVERY.token_endpoint, {
+
+        const { token_endpoint } = await getDiscoveryDocument();
+        const response = await fetch(token_endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body,

--- a/server/src/routes/auth/login.ts
+++ b/server/src/routes/auth/login.ts
@@ -5,10 +5,10 @@ import { info, warning } from 'log';
 import { Pool } from 'postgres';
 
 import { hashUuid } from './util.ts';
+import { getDiscoveryDocument } from '../../cache.ts';
 import { Database } from '../../database.ts';
 import { env } from '../../env.ts';
 import { OAUTH_SCOPE_STRING } from '../../model/oauth/google.ts';
-import { DISCOVERY } from '../../model/oauth/openid.ts';
 
 /**
  * Rejects users that already have a valid session in the database.
@@ -58,7 +58,8 @@ export async function handleLogin(pool: Pool, req: Request) {
         });
 
         // Generate the response headers
-        const headers = new Headers({ Location: `${DISCOVERY.authorization_endpoint}?${params}` });
+        const { authorization_endpoint } = await getDiscoveryDocument();
+        const headers = new Headers({ Location: `${authorization_endpoint}?${params}` });
         setCookie(headers, {
             path: '/',
             name: 'sid',

--- a/server/src/routes/auth/util.ts
+++ b/server/src/routes/auth/util.ts
@@ -4,7 +4,7 @@ import { decode as hexDecode } from 'hex';
 
 import { HeaderSchema } from '../../model/jwk/header.ts';
 import { type IdToken, IdTokenSchema } from '../../model/oauth/openid.ts';
-import { KEYS } from '../../model/oauth/openid.ts';
+import { getCerts } from '../../cache.ts';
 
 /** Takes a UUID v4 string, applies SHA-256, and returns a URL-safe Base64-encoded hash. */
 export async function hashUuid(id: string) {
@@ -30,7 +30,8 @@ export async function parseJwt(jwt: string): Promise<IdToken> {
         ? { name: 'RSASSA-PKCS1-v1_5' }
         : { name: 'ECDSA', hash: 'SHA-256' };
 
-    const key = KEYS.get(kid);
+    const keys = await getCerts();
+    const key = keys.get(kid);
     assert(key?.algorithm.name === algorithm.name);
 
     const encoder = new TextEncoder;


### PR DESCRIPTION
This PR extracts the server's caching logic for [OpenID-related details](https://developers.google.com/identity/openid-connect/openid-connect). They are now located in the `server/src/cache.ts` folder from which all routes can retrieve the latest cached [discovery document](https://developers.google.com/identity/openid-connect/openid-connect#discovery).

One major implication of this change is that we now hit the cache for each request that requires the discovery document. Before, we only initialize the server and retrieve the discovery document from the cache **once** (during initialization). For the rest of the Deno program's lifetime, the server maintains an read-only, in-memory cache of the discovery document. It is never refreshed until the server shuts down and starts up again.

Now, we always check the cache for the latest version (and refresh if expired). Deno's implementation of the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) handles all the data persistence required under the hood.