### PR TITLE
fix(client/sw): ensure service worker scope is `/`

### DIFF
--- a/client/src/pages/register.ts
+++ b/client/src/pages/register.ts
@@ -17,6 +17,9 @@ async function getSubscription(manager: PushManager): Promise<PushSubscription> 
 }
 
 export async function register() {
-    await navigator.serviceWorker.register(new URL('sw.ts', import.meta.url), { type: 'module' });
+    await navigator.serviceWorker.register(new URL('sw.ts', import.meta.url), {
+        type: 'module',
+        scope: '/',
+    });
     const { pushManager } = await navigator.serviceWorker.ready;
 }


### PR DESCRIPTION
It turns out that the default behavior of the service worker registration is to set the scope (i.e., the allowed paths of interception) relative to the current directory of the resource registering the object. [See the MDN page on the `register` function.](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register#examples)

That means we have a funny edge case where if the user happens to visit `/dashboard` first, the service worker's scope will be registered at `/dashboard` **only**. That means we will not be able to intercept requests from `/` (and its descendants such as `/api`). This is a bug!

This PR addresses the issue by explicitly setting the scope of the service worker to `/` at all times.