### PR TITLE
feat(client/api): implement wrapper for user metrics getter

### DIFF
--- a/client/src/api/metrics.ts
+++ b/client/src/api/metrics.ts
@@ -1,0 +1,31 @@
+import {
+    OK,
+    UNAUTHORIZED,
+    FORBIDDEN,
+    NOT_ACCEPTABLE,
+} from 'http-status';
+
+import { type Metrics as MetricsType, MetricsSchema } from '~model/api.ts';
+
+import {
+    InsufficientPermissions,
+    InvalidSession,
+    BadContentNegotiation,
+    UnexpectedStatusCode,
+} from './error.ts';
+
+export namespace Metrics {
+    export async function generateUserSummary(): Promise<MetricsType> {
+        const res = await fetch('/api/metrics/user', {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        });
+        switch (res.status) {
+            case OK: return MetricsSchema.parse(await res.json());
+            case UNAUTHORIZED: throw new InvalidSession;
+            case FORBIDDEN: throw new InsufficientPermissions;
+            case NOT_ACCEPTABLE: throw new BadContentNegotiation;
+            default: throw new UnexpectedStatusCode;
+        }
+    }
+}

--- a/model/src/api.ts
+++ b/model/src/api.ts
@@ -58,6 +58,9 @@ export type InboxEntry = z.infer<typeof InboxEntrySchema>;
 
 export const SummarySchema = z.object({
     status: StatusSchema,
-    amount: z.coerce.bigint().nonnegative(),
+    amount: z.coerce.bigint().positive(),
 });
 export type Summary = z.infer<typeof SummarySchema>;
+
+export const MetricsSchema = z.record(StatusSchema, SummarySchema.shape.amount);
+export type Metrics = z.infer<typeof MetricsSchema>;


### PR DESCRIPTION
As a continuation of #25, this PR implements the client-side wrapper for the `/api/metrics/user` API endpoint.